### PR TITLE
Feat/ci cd terraform secrets

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -45,6 +45,10 @@ module "middleware" {
   book_app_redis_subnet_group_name         = module.network.book_app_redis_subnet_group_name
 }
 
+module "secrets" {
+  source = "./secrets"
+}
+
 module "iam" {
   source                       = "./iam"
   book_app_db_subnet_arns      = module.network.book_app_db_subnet_arns

--- a/infra/secrets/main.tf
+++ b/infra/secrets/main.tf
@@ -1,0 +1,25 @@
+locals {
+  book_app_secrets = {
+    DATABASE_HOST     = "fill_your_db_host"
+    DATABASE_PORT     = 5432
+    DATABASE_NAME     = "app"
+    DATABASE_USERNAME = "fill_your_db_user_name"
+    DATABASE_PASSWORD = "fill_your_db_password"
+    REDIS_HOST        = "fill_your_redist_host"
+    REDIS_PORT        = 6379
+  }
+}
+
+resource "aws_secretsmanager_secret" "book_manager_secrets" {
+  name        = "book-manager-secrets"
+  description = "Secrets for the book manager application"
+  recovery_window_in_days = 0
+  lifecycle {
+    ignore_changes = [name, description]
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "book_manager_secrets" {
+  secret_id     = aws_secretsmanager_secret.book_manager_secrets.id
+  secret_string = jsonencode(local.book_app_secrets)
+}

--- a/infra/secrets/outputs.tf
+++ b/infra/secrets/outputs.tf
@@ -1,0 +1,3 @@
+output "book_app_secrets_manager_arn" {
+  value = aws_secretsmanager_secret.book_manager_secrets.arn
+}


### PR DESCRIPTION
先にappをやろうとしたら、secretないよと怒られる。そりゃそうだ、という感じなのでsecretキーの設定を先に追加。
コンソール側でsecret keyの設定はまだしてない状態でもterraform init, planのコマンドはエラーなく通った。あとで設定しておきます。

<img width="948" alt="image" src="https://github.com/user-attachments/assets/6201805f-a044-4b3f-af73-eb2c6d4c2047" />
