### PR TITLE
modify listen ipv4 depends on env

### DIFF
--- a/api-test.http
+++ b/api-test.http
@@ -1,5 +1,10 @@
 @accessToken = {{login.response.body.accessToken}}
 
+###  health
+
+GET http://localhost:8080/api/v1/health HTTP/1.1
+content-type: application/json
+
 ###  login
 
 # @name login

--- a/src/bin/app.rs
+++ b/src/bin/app.rs
@@ -68,7 +68,11 @@ async fn bootstrap() -> Result<()> {
     #[cfg(debug_assertions)]
     let app = app.merge(Redoc::with_url("/docs", ApiDoc::openapi()));
 
-    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
+    let addr = if cfg!(debug_assertions) {
+        SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080)
+    } else {
+        SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 8080)
+    };
 
     let listener = TcpListener::bind(addr).await?;
     println!("Listening on {}", addr);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/edbcfb2f-b149-448f-8211-4171f6beb349)

ECR周りはうまくいくようになったが、health checkがうまくいってない模様。
localと異なり、本番では全IPをlisten する必要があるため、環境ごとでlisten処理を分けた。
本当は環境変数で管理した方がいいけど、IPV4の設定込みで環境変数対応するのがムズそうなので、確実に動作する実装でいく